### PR TITLE
add perplexity, plot and test pipeline

### DIFF
--- a/KoGPT2/inference.py
+++ b/KoGPT2/inference.py
@@ -1,4 +1,5 @@
 from transformers import GPT2LMHeadModel, PreTrainedTokenizerFast
+from util import perplexity
 
 # inference
 def generate_text(sequence, max_length, top_k=50, top_p=0.95, temperature=0.85):
@@ -17,7 +18,10 @@ def generate_text(sequence, max_length, top_k=50, top_p=0.95, temperature=0.85):
         top_p=top_p, # Top-P 샘플링
         temperature=temperature, # 높을수록 다양한 결과를 내도록 함
     )
-    return tokenizer.decode(outputs[0], skip_special_tokens=True)
+    result = tokenizer.decode(outputs[0], skip_special_tokens=True)
+    ppl = perplexity(model=model, generated_sentence=outputs[0], stride=32)
+    print('Perplexity : ', ppl)
+    return result
 
 
 def main():

--- a/KoGPT2/train.py
+++ b/KoGPT2/train.py
@@ -4,11 +4,10 @@ from transformers import (
     TrainingArguments,
     PreTrainedTokenizerFast
 )
-from util import load_dataset, load_data_collator, perplexity
-
-def compute_metrics(output,target):
-    ppl = perplexity(output,target)
-    return ppl
+from util import load_dataset, load_data_collator, compute_metrics, TextDataset
+from ml_things import plot_dict
+import math
+import torch
 
 # Train
 def train(args):
@@ -28,9 +27,15 @@ def train(args):
                     pad_token='<pad>', mask_token='<mask>')
 
     print('load dataset...')
-    train_dataset = load_dataset(dir_path, tokenizer)
+    train_data, eval_data = load_dataset(dir_path, test_size=0.1)
+    print(f'train_data : {len(train_data)}, eval_data : {len(eval_data)}')
+
+    train_datasets = TextDataset(tokenizer=tokenizer,file_list=train_data, train=True)
+    eval_datasets = TextDataset(tokenizer=tokenizer,file_list=eval_data, train=False)
+
     data_collator = load_data_collator(tokenizer)
     print(f'{dir_path} loaded!')
+    print(f'train_dataset : {len(train_datasets)}, eval_dataset : {len(eval_datasets)}')
     
     tokenizer.save_pretrained(output_dir, legacy_format=False)
     print(f'Tokenizer save_pretrained. {output_dir}')
@@ -38,12 +43,17 @@ def train(args):
     model = GPT2LMHeadModel.from_pretrained(model_name)
     model.save_pretrained(output_dir)
     print(f'Model save_pretrained. {output_dir}')
-    
+
     training_args = TrainingArguments(
         output_dir=output_dir,
         overwrite_output_dir=overwrite_output_dir,
-        per_device_train_batch_size=per_device_train_batch_size,
+        per_device_train_batch_size=4,
+        per_device_eval_batch_size=1,
         num_train_epochs=num_train_epochs,
+        save_total_limit=2,
+        evaluation_strategy='steps', # steps epoch
+        eval_steps=500,  
+        fp16=True,
     )
     print(training_args)
 
@@ -51,8 +61,9 @@ def train(args):
         model=model,
         args=training_args,
         data_collator=data_collator,
-        train_dataset=train_dataset,
-        compute_metrics = compute_metrics,
+        train_dataset=train_datasets,
+        eval_dataset=eval_datasets,
+        compute_metrics=compute_metrics
     )
         
     trainer.train()
@@ -62,5 +73,34 @@ def train(args):
     print(f'model saved.')
 
 
-if __name__ == "__main__":
-    train()
+    # Keep track of train and evaluate loss.
+    loss_history = {'train_loss':[], 'eval_loss':[]}
+
+    # Keep track of train and evaluate perplexity.
+    # This is a metric useful to track for language models.
+    perplexity_history = {'train_perplexity':[], 'eval_perplexity':[]}
+
+    print(trainer.state.log_history)
+    # Loop through each log history.
+    for log_history in trainer.state.log_history:
+        if 'loss' in log_history.keys():
+            # Deal with trianing loss.
+            loss_history['train_loss'].append(log_history['loss'])
+            perplexity_history['train_perplexity'].append(math.exp(log_history['loss']))
+            
+        elif 'eval_loss' in log_history.keys():
+            # Deal with eval loss.
+            loss_history['eval_loss'].append(log_history['eval_loss'])
+            perplexity_history['eval_perplexity'].append(math.exp(log_history['eval_loss']))
+
+    # Plot Losses.
+    plot_dict(loss_history, start_step=training_args.logging_steps, 
+            step_size=training_args.logging_steps, use_title='Loss', 
+            use_xlabel='Train Steps', use_ylabel='Values', path='plot_loss.png', magnify=0.2)
+
+    print()
+
+    # Plot Perplexities.
+    plot_dict(perplexity_history, start_step=training_args.logging_steps, 
+            step_size=training_args.logging_steps, use_title='Perplexity', 
+            use_xlabel='Train Steps', use_ylabel='Values', path='plot_ppl.png', magnify=0.2)

--- a/utils/perplexity_compute_metrics.py
+++ b/utils/perplexity_compute_metrics.py
@@ -6,6 +6,7 @@ def main():
     input_texts = load_dataset("wikitext",
                                         "wikitext-2-raw-v1",
                                         split="test")["text"][:50]
+    print(input_texts, type(input_texts))
     input_texts = [s for s in input_texts if s!='']
     results = perplexity.compute(model_id='gpt2',
                                 input_texts=input_texts)


### PR DESCRIPTION
train/test 데이터 셋 분리와 train loss, perplexity 값 plot 추가 하였습니다(KoGPT2만 적용)

1. perplexity 함수 추가
2. train / test datset 분리 밑 compute metrics 수정 ("pip install --upgrade datasets" 필수)
3. train loss, perplexity plot 추가 ("pip install ml_things" 필수)

* 주의 : 그림 형제 동화 데이터 셋을 넣으면 OOM 문제가 발생합니다. 파일 하나의 크기가 너무 커서 발생한건데 그림 형제 데이터 셋을 지우고 학습하거나 혹은 파일 큰 것들을 여러 파일로 다시 나누어서 데이터 셋을 만들어야 합니다.

그림 형제 데이터 셋은 제외하고 학습 시켜본 결과 OOM 문제는 발생하지 않았습니다.

추가적으로 kogpt, kogpt-trinity 코드가 분리되어 있는데 너무 불필요하다는 생각이 들어 arg로 설정하고 학습 할 수 있도록 합치겠습니다.