### PR TITLE
add rnn based language model

### DIFF
--- a/LanguageModel/data/test.txt
+++ b/LanguageModel/data/test.txt
@@ -1,0 +1,1 @@
+paste your test set

--- a/LanguageModel/data/train.txt
+++ b/LanguageModel/data/train.txt
@@ -1,0 +1,1 @@
+paste your train set

--- a/LanguageModel/data/valid.txt
+++ b/LanguageModel/data/valid.txt
@@ -1,0 +1,1 @@
+paste your valid set

--- a/LanguageModel/dataset.py
+++ b/LanguageModel/dataset.py
@@ -1,0 +1,77 @@
+import os
+import torch
+
+class Dictionary(object):
+    def __init__(self):
+        self.token2id = {}
+        self.id2token = []
+
+    def add_word(self, word):
+        if word not in self.token2id:
+            self.id2token.append(word)
+            self.token2id[word] = len(self.id2token) - 1
+        return self.token2id[word]
+
+    def __len__(self):
+        return len(self.id2token)
+
+class Corpus(object):
+    def __init__(self, path):
+        self.dictionary = Dictionary()
+        self.train = self.tokenize(os.path.join(path, 'train.txt'))
+        self.valid = self.tokenize(os.path.join(path, 'valid.txt'))
+        self.test = self.tokenize(os.path.join(path, 'test.txt'))
+
+    def tokenize(self, path):
+        """Tokenizes a text file."""
+        assert os.path.exists(path)
+        # Add words to the dictionary
+        with open(path, 'r', encoding="utf-8") as f:
+            for line in f:
+                words = line.split() + ['<eos>']
+                for word in words:
+                    self.dictionary.add_word(word)
+
+        # Tokenize file content
+        with open(path, 'r', encoding="utf-8") as f:
+            idss = []
+            for line in f:
+                words = line.split() + ['<eos>']
+                ids = []
+                for word in words:
+                    ids.append(self.dictionary.token2id[word])
+                idss.append(torch.tensor(ids).type(torch.int64))
+            ids = torch.cat(idss)
+
+        return ids
+
+def bptt_batchify(
+    data: torch.Tensor,
+    batch_size: int,
+    sequence_length: int
+):
+    ''' BPTT 배치화 함수
+    한 줄로 길게 구성된 데이터를 받아 BPTT를 위해 배치화합니다.
+    batch_size * sequence_length의 배수에 맞지 않아 뒤에 남는 부분은 잘라버립니다.
+    이 후 배수에 맞게 조절된 데이터로 BPTT 배치화를 진행합니다.
+
+
+    Arguments:
+    data -- 학습 데이터가 담긴 텐서
+            dtype: torch.long
+            shape: [data_lentgh]
+    batch_size -- 배치 크기
+    sequence_length -- 한 샘플의 길이
+
+    Return:
+    batches -- 배치화된 텐서
+               dtype: torch.long
+               shape: [num_sample, batch_size, sequence_length]
+
+    '''
+    batches: torch.Tensor = None
+    length = data.numel() // (batch_size * sequence_length) \
+                           * (batch_size * sequence_length)
+    batches = data[:length].reshape(batch_size, -1, sequence_length).transpose(0, 1)
+
+    return batches

--- a/LanguageModel/inference.py
+++ b/LanguageModel/inference.py
@@ -1,0 +1,62 @@
+import argparse
+
+import os
+import pickle
+import torch
+from dataset import Corpus
+
+from tqdm.notebook import trange
+
+def main(args):
+    num_words = args.num_words
+    temperature = args.temperature
+    output_dir = args.output_dir
+    dir_path = args.dir_path
+    input = args.input
+
+    corpus = None
+    with open(os.path.join(dir_path, 'data_dict.pkl'), 'rb') as f:
+        corpus = pickle.load(f)
+
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    # 가장 좋았던 모았던 모델을 불러옵니다.
+    model = torch.load(os.path.join(output_dir,'model.pt'), map_location=device)
+    # RNN을 로드하는 경우 메모리 연속적으로 들고오지 않기 때문에 이를 연속화해서 Forward 속도를 올릴 수 있습니다. 
+    model.rnn.flatten_parameters()
+
+    hidden = model.init_hidden(1)
+    prev = input
+    input = corpus.dictionary.token2id[input]
+    input = torch.Tensor([[input]])
+    input = input.type(torch.long).to(device)
+
+    outputs = []
+    for i in trange(num_words, desc="Generation"):
+        with torch.no_grad():
+            log_prob, hidden = model(input, hidden)
+
+        weights = (log_prob.squeeze() / temperature).exp()
+        token_id = torch.multinomial(weights, 1)
+        outputs.append(token_id.item())
+        input = token_id.unsqueeze(0)
+
+    outputs = [prev] + [corpus.dictionary.id2token[token_id] for token_id in outputs]
+    print(' '.join(outputs).replace('<eos>', '\n'))
+
+    with open('generate.txt', 'w') as fd:
+        fd.write(' '.join(outputs).replace('<eos>', '\n'))
+
+if __name__ == "__main__":
+    ## Parser 생성하기
+    parser = argparse.ArgumentParser(description="LanguageModel",
+                                    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+
+    parser.add_argument("--input", default='초콜릿', type=str, dest="input")
+    parser.add_argument("--num_words", default=128, type=int, dest="num_words")
+    parser.add_argument("--temperature", default=1.0, type=float, dest="temperature")
+    parser.add_argument("--dir_path", default='data', type=str, dest="dir_path")
+    parser.add_argument("--output_dir", default="models", type=str, dest="output_dir")
+
+    args = parser.parse_args()
+    main(args)
+

--- a/LanguageModel/main.py
+++ b/LanguageModel/main.py
@@ -1,0 +1,24 @@
+## 라이브러리 추가하기
+import argparse
+
+from train import *
+
+if __name__ == "__main__":
+    ## Parser 생성하기
+    parser = argparse.ArgumentParser(description="LanguageModel",
+                                    formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    dir_path = 'data'
+    rnn_type = 'LSTM' # 'LSTM', 'GRU', 'RNN_TANH', 'RNN_RELU'
+    output_dir = 'models'
+    num_train_epochs = 30
+
+    parser.add_argument("--rnn_type", default='LSTM', type=str, dest="rnn_type")
+    parser.add_argument("--num_train_epochs", default=30, type=int, dest="num_train_epochs")
+    parser.add_argument("--dir_path", default='data', type=str, dest="dir_path")
+    parser.add_argument("--output_dir", default="models", type=str, dest="output_dir")
+    parser.add_argument("--batch_size", default=16, type=int, dest="batch_size")
+    parser.add_argument("--sequence_length", default=64, type=int, dest="sequence_length")
+    parser.add_argument("--learning_rate", default=20, type=int, dest="learning_rate")
+    
+    args = parser.parse_args()
+    main(args)

--- a/LanguageModel/model.py
+++ b/LanguageModel/model.py
@@ -1,0 +1,108 @@
+from typing import Union, Tuple
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+class RNNModel(nn.Module):
+    def __init__(self, 
+        rnn_type: str,
+        vocab_size: int,
+        embedding_size: int=200,
+        hidden_size: int=200,
+        num_hidden_layers: int=2,
+        dropout: float=0.5
+    ):
+        super().__init__()
+        self.rnn_type = rnn_type
+        self.vocab_size = vocab_size
+        self.hidden_size = hidden_size
+        self.num_hidden_layer = num_hidden_layers
+        assert rnn_type in {'LSTM', 'GRU', 'RNN_TANH', 'RNN_RELU'}
+
+        # 정수 형태의 id를 고유 벡터 형식으로 나타내기 위하여 학습 가능한 Embedding Layer를 사용합니다.
+        # https://pytorch.org/docs/stable/generated/torch.nn.Embedding.html
+        self.embedding = nn.Embedding(vocab_size, embedding_size)
+
+        # Dropout은 RNN 사용시 많이 쓰입니다.
+        # https://pytorch.org/docs/stable/generated/torch.nn.Dropout.html 
+        self.dropout = nn.Dropout(dropout)
+
+        if rnn_type.startswith('RNN'):
+            # Pytorch에서 제공하는 기본 RNN을 사용해 봅시다.
+            # https://pytorch.org/docs/stable/generated/torch.nn.RNN.html 
+            nonlinearity = rnn_type.split('_')[-1].lower()
+            self.rnn = nn.RNN(
+                embedding_size, 
+                hidden_size, 
+                num_hidden_layers,
+                batch_first=True, 
+                nonlinearity=nonlinearity,
+                dropout=dropout
+            )
+        else:
+            # Pytorch의 LSTM과 GRU를 사용해 봅시다.
+            # LSTM: https://pytorch.org/docs/stable/generated/torch.nn.LSTM.html
+            # RGU: https://pytorch.org/docs/stable/generated/torch.nn.GRU.html
+            self.rnn = getattr(nn, rnn_type)(
+                embedding_size,
+                hidden_size,
+                num_hidden_layers,
+                batch_first=True,
+                dropout=dropout
+            )
+
+        # 최종적으로 나온 hidden state를 이용해 다음 토큰을 예측하는 출력층을 구성합시다.
+        self.projection = nn.Linear(hidden_size, vocab_size)
+
+    def forward(
+        self, 
+        input: torch.Tensor,
+        prev_hidden: Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]
+    ):
+        """ RNN 모델의 forward 함수 구현
+        Arguments:
+        input -- 토큰화 및 배치화된 문장들의 텐서
+                    dtype: torch.long
+                    shape: [batch_size, sequence_lentgh]
+        prev_hidden -- 이전의 hidden state
+                    dtype: torch.float
+                    shape: RNN, GRU - [num_layers, batch_size, hidden_size]
+                           LSTM - ([num_layers, batch_size, hidden_size], [num_layers, batch_size, hidden_size])
+
+        Return:
+        log_prob -- 다음 토큰을 예측한 확률에 log를 취한 값
+                    dtype: torch.float
+                    shape: [batch_size, sequence_length, vocab_size]
+        next_hidden -- 이후의 hidden state
+                    dtype: torch.float
+                    shape: RNN, GRU - [num_layers, batch_size, hidden_size]
+                           LSTM - ([num_layers, batch_size, hidden_size], [num_layers, batch_size, hidden_size])
+        """
+
+        log_prob: torch.Tensor = None
+        next_hidden: Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]] = None
+        
+        emb = self.dropout(self.embedding(input))
+        output, next_hidden = self.rnn(emb, prev_hidden)
+        log_prob = self.projection(self.dropout(output)).log_softmax(dim=-1)
+
+        
+        assert list(log_prob.shape) == list(input.shape) + [self.vocab_size]
+        assert prev_hidden.shape == next_hidden if self.rnn_type != 'LSTM' \
+          else prev_hidden[0].shape == next_hidden[0].shape == next_hidden[1].shape
+        
+        return log_prob, next_hidden
+    
+    def init_hidden(self, batch_size: int):
+        """ 첫 hidden state를 반환하는 함수 """
+        weight = self.projection.weight
+        
+        if self.rnn_type == 'LSTM':
+            return (weight.new_zeros(self.num_hidden_layer, batch_size, self.hidden_size),
+                    weight.new_zeros(self.num_hidden_layer, batch_size, self.hidden_size))
+        else:
+            return weight.new_zeros(self.num_hidden_layer, batch_size, self.hidden_size)
+    
+    @property
+    def device(self):   # 현재 모델의 device를 반환하는 프로퍼티
+        return self.projection.weight.device

--- a/LanguageModel/train.py
+++ b/LanguageModel/train.py
@@ -1,0 +1,148 @@
+import os
+import math
+import pickle
+
+from typing import Union, Tuple
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from dataset import Corpus, bptt_batchify
+from model import RNNModel
+from tqdm.notebook import tqdm
+from torch.nn.utils import clip_grad_norm_
+
+
+def main(args):
+    dir_path = args.dir_path
+    rnn_type = args.rnn_type
+    output_dir = args.output_dir
+    num_epoch = args.num_train_epochs
+    batch_size = args.batch_size
+    sequence_length = args.sequence_length
+    lr = args.learning_rate
+    corpus = Corpus(dir_path)
+
+    vocab_size = len(corpus.dictionary)
+    model = RNNModel(rnn_type, vocab_size=vocab_size)
+
+    train_data = bptt_batchify(corpus.train, batch_size, sequence_length)
+    val_data = bptt_batchify(corpus.valid, batch_size, sequence_length)
+    test_data = bptt_batchify(corpus.test, batch_size, sequence_length)
+
+    lr = 20
+    best_val_loss = None
+
+    device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+    model = model.to(device)
+    
+    if not os.path.exists(output_dir):
+        os.makedirs(output_dir)
+
+    for epoch in range(1, num_epoch+1):
+        train(model, train_data, lr)
+        val_loss = evaluate(model, val_data)
+        print('-' * 89)
+        print(f'| End of epoch {epoch:2d} | valid loss {val_loss:5.2f} | valid ppl {math.exp(val_loss):8.2f}')
+        print('-' * 89)
+
+        if not best_val_loss or val_loss < best_val_loss:
+            torch.save(model, os.path.join(output_dir,'model.pt'))
+            best_val_loss = val_loss
+        else:
+            # 모델이 좋아지지 않으면 학습률을 낮춥니다.
+            lr /= 4.0
+    
+    # Dictonary 저장
+    with open(os.path.join(dir_path, 'data_dict.pkl'), 'wb') as f:
+        pickle.dump(corpus, f)
+
+    # 가장 좋았던 모았던 모델을 불러옵니다.
+    model = torch.load(os.path.join(output_dir,'model.pt'), map_location=device)
+    # RNN을 로드하는 경우 메모리 연속적으로 들고오지 않기 때문에 이를 연속화해서 Forward 속도를 올릴 수 있습니다. 
+    model.rnn.flatten_parameters()
+
+    test_loss = evaluate(model, test_data)
+    print('=' * 89)
+    print(f'| End of training | test loss {test_loss:5.2f} | test ppl {math.exp(test_loss):8.2f}')
+    print('=' * 89)
+
+
+
+
+            
+
+def train(
+    model: RNNModel,
+    data: torch.Tensor,     # Shape: (num_sample, batch_size, sequence_length)
+    lr: float
+):
+    model.train()
+    batch_size = data.shape[1]
+    total_loss = 0.
+
+    hidden = model.init_hidden(batch_size)
+    # tqdm을 이용해 진행바를 만들어 봅시다.
+    progress_bar = tqdm(data, desc="Train")
+    for bid, batch in enumerate(progress_bar, start=1):
+        batch = batch.to(model.device)      # RNN Model에 정의했던 device 프로퍼티를 사용
+
+        output, hidden = model(batch, hidden)
+        if model.rnn_type == 'LSTM':
+            hidden = tuple(tensor.detach() for tensor in hidden)
+        else:
+            hidden = hidden.detach()
+
+        # 손실 함수는 Negative log likelihood로 계산합니다.
+        # https://pytorch.org/docs/stable/generated/torch.nn.NLLLoss.html
+        loss = F.nll_loss(output[:, :-1, :].transpose(1, 2), batch[:, 1:])
+        
+        model.zero_grad()
+        loss.backward()
+        # clip_grad_norm_을 통해 기울기 폭주 (Gradient Exploding) 문제를 방지합니다.
+        clip_grad_norm_(model.parameters(), 0.25)
+        for param in model.parameters():
+            param.data.add_(param.grad, alpha=-lr)
+        
+        total_loss += loss.item()
+        current_loss = total_loss / bid
+
+        # Perplexity는 계산된 Negative log likelihood의 Exponential 입니다.
+        progress_bar.set_description(f"Train - loss {current_loss:5.2f} | ppl {math.exp(current_loss):8.2f} | lr {lr:02.2f}", refresh=False)
+
+
+# 학습 과정이 아니므로 기울기 계산 과정은 불필요합니다. 
+@torch.no_grad()
+def evaluate(
+    model: RNNModel,
+    data: torch.Tensor
+):
+    ''' 모델 평가 코드
+    모델을 받아 해당 데이터에 대해 평가해 평균 Loss 값을 반환합니다.
+    위의 Train 코드를 참고하여 작성해보세요.
+
+    Arguments:
+    model -- 평가할 RNN 모델
+    data -- 평가용 데이터
+            dtype: torch.long
+            shape: [num_sample, batch_size, sequence_length]
+
+    Return:
+    loss -- 계산된 평균 Loss 값
+    '''
+    model.eval()
+
+    loss: float = None
+    total_loss = 0.
+    hidden = model.init_hidden(data.shape[1])
+    
+    for batch in data:
+        batch = batch.to(model.device)
+
+        output, hidden = model(batch, hidden)
+        total_loss += F.nll_loss(output[:, :-1, :].transpose(1, 2), batch[:, 1:]).item()
+    
+    loss = total_loss / len(data)
+    
+
+    return loss


### PR DESCRIPTION
실습 코드 참고해서 RNN-Based Language Model 작성하였습니다.
'LSTM', 'GRU', 'RNN_TANH', 'RNN_RELU'를 사용해볼 수 있고
data폴더의 trian, valid, test 파일에 데이터 넣고 실험하시면 됩니다.

저는 다음과 같은 데이터 셋을 사용하였습니다.
train - splited_grem
valid - splited_ishop
test - splited_sinchun

- RNN 기반 문장 생성이 Transformer 디코더 기반의 gpt 계열의 문장 생성보다 많이 좋지 않은 것을 확인할 수 있었습니다. 많이 좋지 않네요..
- inference 코드로 실험하실 때 문장이 아닌 단어가 되도록 코드를 작성했는데 추후에 문장까지 가능하도록 수정하겠습니다
- vocab을 train dataset에서 띄어쓰기 단위로 만들었는데 추후에 huggingface에서 tokenizer를 가지고 오도록 수정하겠습니다
